### PR TITLE
added better support for cross-package dependencies

### DIFF
--- a/java2typescript-jackson/src/main/java/java2typescript/jackson/module/grammar/base/AbstractNamedType.java
+++ b/java2typescript-jackson/src/main/java/java2typescript/jackson/module/grammar/base/AbstractNamedType.java
@@ -22,6 +22,16 @@ import java.io.Writer;
 abstract public class AbstractNamedType extends AbstractType {
 
 	protected final String name;
+	
+	/**
+	 * If this is non-null this is the name to use to reference a type from another position than from the definition.
+	 */
+	private String nameReferenceOverride;
+	
+	/**
+	 * the full canonical java name.
+	 */
+	private String canonicalName;
 
 	public AbstractNamedType(String className) {
 		this.name = className;
@@ -29,11 +39,23 @@ abstract public class AbstractNamedType extends AbstractType {
 
 	@Override
 	public void write(Writer writer) throws IOException {
-		writer.write(name);
+		writer.write(nameReferenceOverride != null ? nameReferenceOverride : name);
 	}
 
 	public String getName() {
 		return name;
+	}
+	
+	public void setNameReferenceOverride(String nameReferenceOverride) {
+		this.nameReferenceOverride = nameReferenceOverride;
+	}
+	
+	public String getCanonicalName() {
+		return canonicalName;
+	}
+	
+	public void setCanonicalName(String javaPackage) {
+		this.canonicalName = javaPackage;
 	}
 
 	abstract public void writeDef(Writer writer) throws IOException;

--- a/java2typescript-jackson/src/main/java/java2typescript/jackson/module/visitors/TSJsonFormatVisitorWrapper.java
+++ b/java2typescript-jackson/src/main/java/java2typescript/jackson/module/visitors/TSJsonFormatVisitorWrapper.java
@@ -15,6 +15,7 @@
  ******************************************************************************/
 package java2typescript.jackson.module.visitors;
 
+import java2typescript.jackson.module.grammar.ClassType;
 import java2typescript.jackson.module.grammar.EnumType;
 import java2typescript.jackson.module.grammar.Module;
 import java2typescript.jackson.module.grammar.base.AbstractNamedType;
@@ -87,7 +88,10 @@ public class TSJsonFormatVisitorWrapper extends ABaseTSJsonFormatVisitor impleme
 
 		if (namedType == null) {
 			TSJsonObjectFormatVisitor visitor = new TSJsonObjectFormatVisitor(this, name, javaType.getRawClass());
-			type = visitor.getType();
+			ClassType classType = visitor.getType();
+			classType.setCanonicalName(javaType.getRawClass().getCanonicalName());
+			type = classType;
+			
 			getModule().getNamedTypes().put(visitor.getType().getName(), visitor.getType());
 			return visitor;
 		} else {
@@ -104,6 +108,7 @@ public class TSJsonFormatVisitorWrapper extends ABaseTSJsonFormatVisitor impleme
 			for (Object val : javaType.getRawClass().getEnumConstants()) {
 				enumType.getValues().add(val.toString());
 			}
+			enumType.setCanonicalName(javaType.getRawClass().getCanonicalName());
 			getModule().getNamedTypes().put(name, enumType);
 			return enumType;
 		} else {


### PR DESCRIPTION
when splitting outcome dtos into two packages it is sometimes necessary to
reference classes by a import prefix. This hack allows setting a
reference-overwrite name which will be used when referencing a type.
